### PR TITLE
Fix mentorship export: #185

### DIFF
--- a/include/generalized_download_script.php
+++ b/include/generalized_download_script.php
@@ -1213,12 +1213,12 @@ function generalized_download($download_name, $permissions, $enlace_session_stri
         'titles' => array("Event ID", "Event Name", "Event Date", "Participant ID", "Role")),
 
         'enlace_mentorship_hours'=>array('db'=>'enlace', 'query'=>        
-        'SELECT Participant_ID, Mentorship_Date, Mentorship_Hours_Logged, First_Name, Last_Name, Name FROM Participants_Mentorship INNER JOIN Participants ON Participant_ID=Mentee_ID INNER JOIN Programs ON Program_Id=Mentorship_Program',
-        'titles' => array("Participant ID", "Mentorship Date", "Mentorship Hours", "First_Name", "Last_Name", "Program")),
+        'SELECT Participant_ID, Mentorship_Date, Mentorship_Hours_Logged, First_Name, Last_Name, Session_Name FROM Participants_Mentorship INNER JOIN Participants ON Participant_ID=Mentee_ID INNER JOIN Session_Names ON Session_Id=Mentorship_Program',
+        'titles' => array("Participant ID", "Mentorship Date", "Mentorship Hours", "First_Name", "Last_Name", "Session Name")),
 
         'enlace_mentorship_hours_deid'=>array('db'=>'enlace', 'query'=>        
-        'SELECT Participant_ID, Mentorship_Date, Mentorship_Hours_Logged, Name FROM Participants_Mentorship INNER JOIN Participants ON Participant_ID=Mentee_ID INNER JOIN Programs ON Program_Id=Mentorship_Program',
-        'titles' => array("Participant ID", "Mentorship Date", "Mentorship Hours", "Program")),
+        'SELECT Participant_ID, Mentorship_Date, Mentorship_Hours_Logged, Session_Name FROM Participants_Mentorship INNER JOIN Participants ON Participant_ID=Mentee_ID INNER JOIN Session_Names ON Session_Id=Mentorship_Program',
+        'titles' => array("Participant ID", "Mentorship Date", "Mentorship Hours", "Session Name")),
 
         'enlace_programs'=>array('db'=>'enlace', 'query'=> 
         'SELECT Programs.*, Institution_Name FROM Programs LEFT JOIN Institutions ON Host=Inst_ID',


### PR DESCRIPTION
The query for exporting mentorship hours incorrectly referred to
Programs instead of Sessions.  The export appeared to be working as long
as the number of programs and sessions was roughly equivalent, though
the "program" named in the export was never correct.  The illusion of
success was caused by the fact that if there was a session with id "10,"
there was likely also a program with id "10."  Now that there are
hundreds of sessions and only dozens of programs, it's highly likely
that a session ID will not correspond to any program.  Because this was
an inner join, mentorship hours without a corresponding program ID were
not returned by the query.

Note that this is one instance of a general problem with the database
schema: programs and sessions are unclearly differentiated.  In some
cases a table refers to a "program id" when it really means a "session
id."  The converse is less frequent.