### PR TITLE
Fix #221: Enlace: Add survey entry point link

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -50,3 +50,31 @@ This setting affects what programs/sessions are visible in different pages.  If 
 USE ttm-enlace
 INSERT INTO System_Settings VALUES ('num_days_hidden', 'integer', '365');
 ```
+
+## Issue 221 - Enlace - Add survey entry point link - create table with codes for assessments.
+
+Adds a table for storing unique codes that allow a user to bypass authentication to take a distinct survey.
+
+### SQL for Assessments_Codes
+
+```
+USE ttm-enlace
+CREATE TABLE `Assessments_Codes` (
+  `Assessment_Code_ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Participant_ID` int NOT NULL,
+  `Session_ID` int NOT NULL,
+  `Pre_Post` int NOT NULL,
+  `Code` char(8) NOT NULL,
+  PRIMARY KEY (`Assessment_Code_ID`));
+```
+
+
+## Issue 221 - Enlace - Add survey entry point link - Add survey_entry_point_salt - September 2018
+
+Adds a setting for the entry_point_salt, which is used to generate a hash for a way to enter surveys without a login.  This should not be used for anything truly secure (like passwords), but is useful for the purpose
+
+### SQL for survey_entry_point_salt setting
+```
+USE ttm-enlace
+INSERT INTO System_Settings VALUES ('survey_entry_point_salt', 'string', 'defaultsalt');
+```

--- a/data/lisc-ttm-sample-data.sql
+++ b/data/lisc-ttm-sample-data.sql
@@ -4234,7 +4234,7 @@ CREATE TABLE `System_Settings` (
 
 LOCK TABLES `System_Settings` WRITE;
 /*!40000 ALTER TABLE `System_Settings` DISABLE KEYS */;
-INSERT INTO `System_Settings` VALUES ('num_days_hidden','integer','365');
+INSERT INTO `System_Settings` VALUES ('num_days_hidden','integer','365'),('survey_entry_point_salt','string','defaultsalt');
 /*!40000 ALTER TABLE `System_Settings` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/enlace/ajax/save_assessments.php
+++ b/enlace/ajax/save_assessments.php
@@ -20,13 +20,27 @@
 <?php
 include $_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php";
 include $_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php";
+include "../include/survey_entry_point.php";
 
-user_enforce_has_access($Enlace_id, $DataEntryAccess);
+include "../include/dbconnopen.php";
+$person_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['person']);
+$pre_post_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['pre_post']);
+$program_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['program']);
+include "../include/dbconnclose.php";
+
+$anonymous_entry = false;
+if ($_POST['edited'] != 1 && isset($_POST['code'])) {
+    $lookup_result = lookup_and_validate_survey_entry_code($_POST['code'], $pre_post_sqlsafe);
+    $person_sqlsafe = $lookup_result['Participant_ID'];
+    $program_sqlsafe = $lookup_result['Session_ID'];
+    $anonymous_entry = true;
+} else {
+    user_enforce_has_access($Enlace_id, $DataEntryAccess);
+}
 
 /* save new or edited assessments. */
 /*escape all posted variables:*/
 include "../include/dbconnopen.php";
-$person_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['person']);
 $attn_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['attn']);
 $check_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['check']);
 $praise_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['praise']);
@@ -35,8 +49,6 @@ $crisis_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['crisis']);
 $advice_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['advice']);
 $know_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['know']);
 $important_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['important']);
-$program_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['program']);
-$pre_post_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['pre_post']);
 
 $fear_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['fear']);
 $prevent_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['prevent']);

--- a/enlace/ajax/survey_code.php
+++ b/enlace/ajax/survey_code.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ *   TTM is a web application to manage data collected by community organizations.
+ *   Copyright (C) 2014, 2015, 2018  Local Initiatives Support Corporation (lisc.org)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+?>
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php";
+include $_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php";
+include "../include/survey_entry_point.php";
+
+user_enforce_has_access($Enlace_id, $DataEntryAccess);
+
+header("Content-type:application/json");
+
+include "../include/dbconnopen.php";
+$session_id_sqlsafe = mysqli_real_escape_string($cnnEnlace, $_POST['session_id']);
+$participant_id_sqlsafe = mysqli_real_escape_string($cnnEnlace, $_POST['participant_id']);
+$pre_post_sqlsafe = mysqli_real_escape_string($cnnEnlace, $_POST['pre_post']);
+
+if($session_id_sqlsafe != '') {
+    echo json_encode(array(
+      'code' => generate_survey_entry_code($participant_id_sqlsafe, $session_id_sqlsafe, $pre_post_sqlsafe)
+    ));
+}
+?>
+

--- a/enlace/classes/participant.php
+++ b/enlace/classes/participant.php
@@ -21,8 +21,6 @@
 include_once($_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php");
 include_once($_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php");
 
-user_enforce_has_access($Enlace_id);
-
 require_once("assessment.php");
 
 class Participant {

--- a/enlace/header.php
+++ b/enlace/header.php
@@ -41,7 +41,7 @@
             <td class="menu_item"><a href="/enlace/campaigns/campaigns.php" id="campaigns_selector">Campaigns</a></td>
             <td class="menu_item"><a href="/enlace/events/events.php" id="events_selector">Events</a></td>
             <td class="menu_item"><a href="/enlace/reports/reports.php" id="reports_selector">Reports</a></td>
-            <?php if ($USER->has_site_access($Enlace_id, $AdminAccess)) { ?>
+            <?php if ($USER && $USER->has_site_access($Enlace_id, $AdminAccess)) { ?>
                 <td class="menu_item"><a href="/enlace/system/settings.php" id="settings_selector">Settings</a>
             <?php } ?>
             <td class="menu_item"><a href="/index.php?action=logout">Log Out</a>

--- a/enlace/include/datepicker_wtw.php
+++ b/enlace/include/datepicker_wtw.php
@@ -21,7 +21,6 @@
 include_once($_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php");
 include_once($_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php");
 
-user_enforce_has_access($Enlace_id);
 ?>
         <link href="/include/jquery/1.9.1/css/redmond/jquery-ui-1.8.23.custom.css" rel="stylesheet" type="text/css" />
         <script src="/include/jquery/1.9.1/js/jquery-1.8.2.js" type="text/javascript"></script>

--- a/enlace/include/settings.php
+++ b/enlace/include/settings.php
@@ -27,6 +27,7 @@ if (!function_exists("get_setting")) {
      */
 
     $NumDaysHiddenSetting = "num_days_hidden";
+    $SurveyEntryPointSalt = "survey_entry_point_salt";
 
     function get_setting_tuple ( $setting_name ) {
         include $_SERVER['DOCUMENT_ROOT'] . "/enlace/include/dbconnopen.php";

--- a/enlace/include/survey_entry_point.php
+++ b/enlace/include/survey_entry_point.php
@@ -1,0 +1,133 @@
+<?php
+/*
+ *   TTM is a web application to manage data collected by community organizations.
+ *   Copyright (C) 2014, 2015  Local Initiatives Support Corporation (lisc.org)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+?>
+<?php
+include_once("settings.php");
+include_once("../classes/participant.php");
+
+if (!function_exists("find_survey_entry_code_in_db")) {
+
+    function find_survey_entry_code_in_db ( $participant_id, $session_id, $pre_post ) {
+        $lookup = "SELECT Code FROM Assessments_Codes " .
+            " WHERE Participant_ID = $participant_id " .
+            "       AND Session_ID = $session_id " .
+            "       AND Pre_Post = $pre_post ";
+
+        include "../include/dbconnopen.php";
+        $lookup_result = mysqli_query($cnnEnlace, $lookup);
+        include "../include/dbconnclose.php";
+
+        return (mysqli_num_rows($lookup_result) > 0) ? mysqli_fetch_row($lookup_result)[0] : false;
+    }
+
+    function generate_new_survey_entry_code ( $participant_id, $session_id, $pre_post ) {
+        $code = [];
+
+        // Base 32 for readability: https://en.wikipedia.org/wiki/Base32
+        foreach(range(1, 8) as $idx) {
+           $val = rand(0, 32);
+           if($val < 26) {
+               $val = chr(ord('A') + $val);
+           } else {
+               $val = $val - 24;
+           }
+           $code[] = $val;
+        }
+        $code_str = join('', $code);
+
+        include "../include/dbconnopen.php";
+        //Check to see if in db, if so, recurse.  Potentially infinitely.
+        //But, only after 32^6 or so codes have been generated do I think we'll see problems.
+        if(mysqli_num_rows(mysqli_query($cnnEnlace, "SELECT * FROM Assessments_Codes WHERE Code = '$code_str'")) > 0) {
+            return generate_new_survey_entry_code ($participant_id, $session_id, $pre_post);
+        } else {
+            $insert_code = "INSERT INTO Assessments_Codes (Participant_ID, Session_ID, Pre_Post, Code) " .
+                " VALUES ($participant_id, $session_id, $pre_post, '$code_str')";
+    
+            mysqli_query($cnnEnlace, $insert_code);
+            include "../include/dbconnclose.php";
+    
+            return $code_str;
+        }
+    }
+
+    function generate_survey_entry_code( $participant_id, $session_id, $pre_post ) {
+        $possible_code = find_survey_entry_code_in_db($participant_id, $session_id, $pre_post);
+        return $possible_code ? $possible_code : generate_new_survey_entry_code($participant_id, $session_id, $pre_post);
+    }
+
+    function lookup_survey_code_pre_post( $code ) {
+        $lookup = "SELECT Pre_Post FROM Assessments_Codes WHERE Code = '" . strtoupper($code) . "'";
+
+        include "../include/dbconnopen.php";
+        $lookup_result = mysqli_query($cnnEnlace, $lookup);
+
+        if (mysqli_num_rows($lookup_result) == 0) {
+            $die_unauthorized();
+        }
+
+        return mysqli_fetch_row($lookup_result)[0];
+    }
+
+    // Not only validates the hash, but ensures the survey is available for using
+    function lookup_and_validate_survey_entry_code( $code, $expected_pre_post ) {
+        global $die_unauthorized;
+
+        $lookup = "SELECT * FROM Assessments_Codes WHERE Code = '" . strtoupper($code) . "'";
+
+        include "../include/dbconnopen.php";
+        $lookup_result = mysqli_query($cnnEnlace, $lookup);
+
+        if (mysqli_num_rows($lookup_result) == 0) {
+            $die_unauthorized();
+        }
+
+        $lookup_row = mysqli_fetch_array($lookup_result);
+
+        if($expected_pre_post != $lookup_row['Pre_Post']) {
+            $die_unauthorized();
+        }
+
+        $participant_id = $lookup_row['Participant_ID'];
+        $session_id = $lookup_row['Session_ID'];
+        $pre_post = $lookup_row['Pre_Post'];
+
+        $assessment_sql = "SELECT * FROM Assessments " .
+            "WHERE Session_ID = '$session_id' " .
+            "AND Participant_ID = '$participant_id' " .
+            "AND Pre_Post = $pre_post;";
+        $assessment_result = mysqli_query($cnnEnlace, $assessment_sql);
+
+        if(mysqli_num_rows($assessment_result) > 0) {
+            $die_unauthorized();
+        }
+
+        $in_program_sql = "SELECT * FROM Participants_Programs " .
+            "WHERE Program_ID = '$session_id' " .
+            "AND Participant_ID = '$participant_id'";
+        $in_program_result = mysqli_query($cnnEnlace, $in_program_sql);
+        if(mysqli_num_rows($in_program_result) == 0) {
+            $die_unauthorized();
+        }
+        include "../include/dbconnclose.php";
+
+        return $lookup_row;
+    }
+}
+?>

--- a/enlace/participants/survey.php
+++ b/enlace/participants/survey.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ *   TTM is a web application to manage data collected by community organizations.
+ *   Copyright (C) 2014, 2015, 2018  Local Initiatives Support Corporation (lisc.org)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+?>
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php";
+include $_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php";
+include "../include/survey_entry_point.php";
+
+include "../include/dbconnopen.php";
+$code_sqlsafe = mysqli_real_escape_string($cnnEnlace, $_GET['code']);
+include "../include/dbconnclose.php";
+$pre_post = lookup_survey_code_pre_post($code_sqlsafe);
+
+if($pre_post == '1') {
+    include "all_intake.php";
+} else {
+    include "all_impact.php";
+}

--- a/login_page.php
+++ b/login_page.php
@@ -29,7 +29,7 @@
                 </td>
             </tr>
             <tr>
-                <td>
+                <td width="100" align="right">
                     Username:
                 </td>
                 <td>
@@ -37,13 +37,13 @@
                 </td>
             </tr>
             <tr>
-                <td>
+                <td width="100" align="right">
                     Password:
                 </td>
                 <td>
                     <input type="password" name="password" id="password" maxlength="50" />
                 </td>
-                <td>
+                <td width=150>
                     <!--
                     Link to page where users can reset their own passwords.
                     -->
@@ -54,6 +54,33 @@
                 <td colspan="2" align="center">
                     <div id="login_error" style="color: #ff0000;"></div>
                     <input type="submit" value="Log In" id="login_submit_button"/>
+                </td>
+            </tr>
+        </table>
+    </form>
+
+<br/>
+<br/>
+
+    <form action="/enlace/participants/survey.php" method="get">
+        <table>
+            <tr>
+                <td colspan="2" align="center">
+                    <h3>Take a Survey</h3>
+                </td>
+            </tr>
+            <tr>
+                <td width="100" align="right">
+                    Survey Code:
+                </td>
+                <td>
+                    <input type="text" name="code" id="code" maxlength="50" />
+                </td>
+                <td width=150></td>
+            </tr>
+            <tr>
+                <td colspan="2" align="center">
+                    <input type="submit" value="Take Survey">
                 </td>
             </tr>
         </table>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1203,6 +1203,28 @@ div.x-closer {
   cursor:pointer;
 }
 
+div.middlepopup {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  margin-left: -175px;
+  margin-top: -120px;
+  width: 320px;
+  height: 210px;
+  background-color: white;
+  border: 2px solid black;
+  box-shadow: 5px 5px 25px #000;
+  padding: 15px;
+  z-index:5;
+  display:none;
+}
+
+p.survey-code {
+  font-size:120%;
+  text-align:center;
+
+}
+
 div.popupcontainer {
   z-index:2;
 }


### PR DESCRIPTION
This adds an entry point to the intake/impact surveys without logging in.  To do this, it creates an effectively unique id based on the name of the person, the session, and a salt.  This was chosen over
maintaining a GUID list somewhere in the database for ease of development and maintenance.

Test by logging in, going to a program with someone who doesn't have an intake or impact survey, and clicking on the link next to the lack of survey.  Then log out and refresh link.  Enter survey, and link should no longer work.

Merge against 220 because these were done in order to save rebase time for testing purposes.