### PR TITLE
Add days of week to session

### DIFF
--- a/DATABASE.org
+++ b/DATABASE.org
@@ -457,6 +457,17 @@ youth programs.
 | Start_Date   | date        | YES  |     | NULL    |                |
 | End_Date     | date        | YES  |     | NULL    |                |
 | Survey_Due   | date        | YES  |     | NULL    |                |
+| Start_Hour   | int(11)     | YES  |     | NULL    |                |
+| Start_Suffix | varchar(45) | YES  |     | NULL    |                |
+| End_Hour     | int(11)     | YES  |     | NULL    |                |
+| End_Suffix   | varchar(45) | YES  |     | NULL    |                |
+| Monday       | int(11)     | YES  |     | NULL    |                |
+| Tuesday      | int(11)     | YES  |     | NULL    |                |
+| Wednesday    | int(11)     | YES  |     | NULL    |                |
+| Thursday     | int(11)     | YES  |     | NULL    |                |
+| Friday       | int(11)     | YES  |     | NULL    |                |
+| Saturday     | int(11)     | YES  |     | NULL    |                |
+| Sunday       | int(11)     | YES  |     | NULL    |                |
 |--------------+-------------+------+-----+---------+----------------+
 
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -78,3 +78,40 @@ Adds a setting for the entry_point_salt, which is used to generate a hash for a 
 USE ttm-enlace
 INSERT INTO System_Settings VALUES ('survey_entry_point_salt', 'string', 'defaultsalt');
 ```
+
+# Issue 222 - Enlace - Sessions have their own Days of week and Daily Start and End hours - September 2018
+
+Adds days of week, start, and end times to the Session_Names table, so that there's greater flexibility in the application for how different sessions in different times of the year.  This will affect how session dates get populated, and how the dosage calculations work.  We keep the Programs values around in order provide defaults.
+
+### SQL for column additions
+```
+USE ttm-enlace
+ALTER TABLE `Session_Names`
+    ADD COLUMN `Start_Hour` int(11),
+    ADD COLUMN `Start_Suffix` varchar(45),
+    ADD COLUMN `End_Hour` int(11),
+    ADD COLUMN `End_Suffix` varchar(45),
+    ADD COLUMN `Monday` int(11),
+    ADD COLUMN `Tuesday` int(11),
+    ADD COLUMN `Wednesday` int(11),
+    ADD COLUMN `Thursday` int(11),
+    ADD COLUMN `Friday` int(11),
+    ADD COLUMN `Saturday` int(11),
+    ADD COLUMN `Sunday` int(11);
+```
+
+### SQL for backfilling old sessions
+```
+USE ttm-enlace
+UPDATE `Session_Names` SET `Start_Hour` = (SELECT `Start_Hour` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Start_Suffix` = (SELECT `Start_Suffix` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `End_Hour` = (SELECT `End_Hour` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `End_Suffix` = (SELECT `End_Suffix` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Monday` = (SELECT `Monday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Tuesday` = (SELECT `Tuesday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Wednesday` = (SELECT `Wednesday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Thursday` = (SELECT `Thursday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Friday` = (SELECT `Friday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Saturday` = (SELECT `Saturday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+UPDATE `Session_Names` SET `Sunday` = (SELECT `Sunday` FROM `Programs` WHERE `Programs`.`Program_ID` = `Session_Names`.`Program_ID`);
+```

--- a/data/lisc-ttm-sample-data.sql
+++ b/data/lisc-ttm-sample-data.sql
@@ -4197,6 +4197,17 @@ CREATE TABLE `Session_Names` (
   `Start_Date` date DEFAULT NULL,
   `End_Date` date DEFAULT NULL,
   `Survey_Due` date DEFAULT NULL,
+  `Start_Hour` int(11) DEFAULT NULL,
+  `Start_Suffix` varchar(45) DEFAULT NULL,
+  `End_Hour` int(11) DEFAULT NULL,
+  `End_Suffix` varchar(45) DEFAULT NULL,
+  `Monday` int(11) DEFAULT NULL,
+  `Tuesday` int(11) DEFAULT NULL,
+  `Wednesday` int(11) DEFAULT NULL,
+  `Thursday` int(11) DEFAULT NULL,
+  `Friday` int(11) DEFAULT NULL,
+  `Saturday` int(11) DEFAULT NULL,
+  `Sunday` int(11) DEFAULT NULL,
   PRIMARY KEY (`Session_ID`),
   KEY `FK_Session_Names__Programs__Program_ID_idx` (`Program_ID`),
   CONSTRAINT `FK_Session_Names__Programs__Program_ID` FOREIGN KEY (`Program_ID`) REFERENCES `Programs` (`Program_ID`) ON DELETE NO ACTION ON UPDATE NO ACTION
@@ -4209,7 +4220,7 @@ CREATE TABLE `Session_Names` (
 
 LOCK TABLES `Session_Names` WRITE;
 /*!40000 ALTER TABLE `Session_Names` DISABLE KEYS */;
-INSERT INTO `Session_Names` VALUES (1,'',2,NULL,NULL,NULL),(3,'Spring 2013',2,NULL,NULL,NULL),(4,'Fall 2013',2,NULL,NULL,NULL),(5,'Summer 2013',8,NULL,NULL,NULL),(6,'Fall Semester 2013',6,'2013-08-26','2013-12-20','2014-01-10'),(7,'Summer 2013: Never Doubted For a Moment',13,'2013-06-10','2013-08-23','2013-09-20'),(8,'Fall 2013',1,'0000-00-00','0000-00-00','0000-00-00'),(9,'Spring-Summer 2012',3,'0000-00-00','0000-00-00','0000-00-00'),(10,'Beta Edition',4,'0000-00-00','0000-00-00','2013-08-10'),(11,'Welcome Autumn, 2013',5,'0000-00-00','0000-00-00','0000-00-00'),(12,'2013 Meetings',7,'0000-00-00','0000-00-00','0000-00-00'),(13,'Spring 2013',9,'0000-00-00','0000-00-00','0000-00-00'),(14,'Summer 2013 Camp Session',11,'0000-00-00','0000-00-00','0000-00-00'),(15,'Final Test Session (not really though)',10,'0000-00-00','0000-00-00','0000-00-00'),(16,'Spring 2013',11,'2013-07-01','2013-08-31','2013-08-19'),(17,'2012 Mentorship Setup',7,'2012-08-01','2012-11-30','2012-11-23'),(18,'Fall 2013',15,'2013-09-03','2013-12-20','0000-00-00'),(19,'Fall 2013',16,'2013-09-09','2013-12-13','2013-12-06'),(20,'Session Whatever',17,'0000-00-00','0000-00-00','2013-08-28'),(25,'Autumn 2013',13,'0000-00-00','0000-00-00','2013-09-16'),(26,'Fall 2013 - Alternates',1,'0000-00-00','0000-00-00','2013-09-17'),(30,'SSSSSSSSSSSS',19,'2014-02-04','2014-02-27','2014-02-20');
+INSERT INTO `Session_Names` VALUES (1,'',2,NULL,NULL,NULL,8,'am',12,'am',0,1,0,1,0,0,0),(3,'Spring 2013',2,NULL,NULL,NULL,8,'am',12,'am',0,1,0,1,0,0,0),(4,'Fall 2013',2,NULL,NULL,NULL,8,'am',12,'am',0,1,0,1,0,0,0),(5,'Summer 2013',8,NULL,NULL,NULL,0,'',0,'',1,0,1,0,1,0,0),(6,'Fall Semester 2013',6,'2013-08-26','2013-12-20','2014-01-10',0,'',0,'',0,0,0,0,0,0,0),(7,'Summer 2013: Never Doubted For a Moment',13,'2013-06-10','2013-08-23','2013-09-20',0,'',0,'',0,0,0,0,0,0,0),(8,'Fall 2013',1,'0000-00-00','0000-00-00','0000-00-00',4,'pm',6,'pm',0,1,0,1,0,1,0),(9,'Spring-Summer 2012',3,'0000-00-00','0000-00-00','0000-00-00',0,'',0,'',1,0,0,0,0,0,0),(10,'Beta Edition',4,'0000-00-00','0000-00-00','2013-08-10',12,'am',4,'pm',1,0,1,0,0,0,0),(11,'Welcome Autumn, 2013',5,'0000-00-00','0000-00-00','0000-00-00',0,'',0,'',0,0,0,0,0,0,0),(12,'2013 Meetings',7,'0000-00-00','0000-00-00','0000-00-00',0,'',0,'',1,0,1,0,1,0,0),(13,'Spring 2013',9,'0000-00-00','0000-00-00','0000-00-00',6,'pm',8,'pm',0,0,1,0,1,0,0),(14,'Summer 2013 Camp Session',11,'0000-00-00','0000-00-00','0000-00-00',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(15,'Final Test Session (not really though)',10,'0000-00-00','0000-00-00','0000-00-00',0,'',0,'',0,0,0,0,0,0,0),(16,'Spring 2013',11,'2013-07-01','2013-08-31','2013-08-19',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(17,'2012 Mentorship Setup',7,'2012-08-01','2012-11-30','2012-11-23',0,'',0,'',1,0,1,0,1,0,0),(18,'Fall 2013',15,'2013-09-03','2013-12-20','0000-00-00',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(19,'Fall 2013',16,'2013-09-09','2013-12-13','2013-12-06',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(20,'Session Whatever',17,'0000-00-00','0000-00-00','2013-08-28',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(25,'Autumn 2013',13,'0000-00-00','0000-00-00','2013-09-16',0,'',0,'',0,0,0,0,0,0,0),(26,'Fall 2013 - Alternates',1,'0000-00-00','0000-00-00','2013-09-17',4,'pm',6,'pm',0,1,0,1,0,1,0),(30,'SSSSSSSSSSSS',19,'2014-02-04','2014-02-27','2014-02-20',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
 /*!40000 ALTER TABLE `Session_Names` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/enlace/ajax/add_date.php
+++ b/enlace/ajax/add_date.php
@@ -37,11 +37,9 @@ else if ($_POST['action']=='generate'){
     include "../include/dbconnopen.php";
     $session_id_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['session_id']);
     $session_query = "SELECT * FROM Session_Names WHERE Session_ID='$session_id_sqlsafe'";
-    $session_info = mysqli_fetch_row(mysqli_query($cnnEnlace, $session_query));
+    $session_info = mysqli_fetch_array(mysqli_query($cnnEnlace, $session_query));
     if($session_info !== FALSE && $session_info[3] != '0000-00-00' && $session_info[4] != '0000-00-00' &&
        $session_info[3] < $session_info[4]) {
-        $program_query = "SELECT * FROM Programs WHERE Program_ID='".$session_info[2]."'";
-        $program_info = mysqli_fetch_array(mysqli_query($cnnEnlace, $program_query));
         date_default_timezone_set('America/Chicago');
         $session_start = new DateTime($session_info[3]);
         $session_end = new DateTime($session_info[4]);
@@ -52,7 +50,7 @@ else if ($_POST['action']=='generate'){
             // want to count on it.
             $days = array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
 
-            if($program_info[$days[$date_to_add->format('w')]] == 1) {
+            if($session_info[$days[$date_to_add->format('w')]] == 1) {
                 $new_date="INSERT INTO Program_Dates (Program_ID, Date_Listed) VALUES
                     ('".$session_id_sqlsafe."', '".$date_to_add->format('Y-m-d')."')";
                 mysqli_query($cnnEnlace, $new_date);

--- a/enlace/ajax/edit_program.php
+++ b/enlace/ajax/edit_program.php
@@ -35,8 +35,32 @@ if ($_POST['action'] == 'new_session') {
     $end_session = new DateTime($end_sqlsafe);
     $survey_date = $end_session->sub(new DateInterval('P7D'));
     $survey_date = $survey_date->format('Y-m-d');
-    $new_session = "INSERT INTO Session_Names (Session_Name, Program_ID, Start_Date, End_Date, Survey_Due) VALUES ('" . $_POST['session'] . "', 
-        '" . $program_sqlsafe . "', '" . $start_sqlsafe . "', '" . $end_sqlsafe . "', '" . $survey_date . "')";
+
+    $name_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['name']);
+
+    $start_hour_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['start_hour']);
+    $end_hour_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['end_hour']);
+    $start_suffix_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['start_suffix']);
+    $end_suffix_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['end_suffix']);
+
+    $mon_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['mon']);
+    $tue_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['tue']);
+    $wed_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['wed']);
+    $thur_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['thur']);
+    $fri_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['fri']);
+    $sat_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['sat']);
+    $sun_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['sun']);
+
+    $new_session = "INSERT INTO Session_Names " .
+        " (Session_Name, Program_ID, Start_Date, End_Date, Survey_Due, ".
+        "  Start_Hour, Start_Suffix, End_Hour, End_Suffix, Monday," .
+        "  Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)" .
+        " VALUES" .
+        " ('$name_sqlsafe', '$program_sqlsafe', '$start_sqlsafe', '$end_sqlsafe', '$survey_date', " .
+        "  '$start_hour_sqlsafe', '$start_suffix_sqlsafe', '$end_hour_sqlsafe', '$end_suffix_sqlsafe', " .
+        "  '$mon_sqlsafe', '$tue_sqlsafe', '$wed_sqlsafe', '$thur_sqlsafe', '$fri_sqlsafe', " .
+        "  '$sat_sqlsafe', '$sun_sqlsafe')";
+
     echo $new_session;
     mysqli_query($cnnEnlace, $new_session);
     include "../include/dbconnclose.php";
@@ -55,10 +79,37 @@ if ($_POST['action'] == 'new_session') {
 }
 /* change a session name: */ elseif ($_POST['action'] == 'edit_session') {
     include "../include/dbconnopen.php";
-    $new_name_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['new_name']);
     $id_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['id']);
-    $edit_session = "UPDATE Session_Names SET Session_Name='" . $_POST['new_name'] . "' WHERE Session_ID='" . $_POST['id'] . "'";
-    echo $edit_session;
+
+    $name_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['name']);
+
+    $start_hour_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['start_hour']);
+    $end_hour_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['end_hour']);
+    $start_suffix_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['start_suffix']);
+    $end_suffix_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['end_suffix']);
+
+    $mon_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['mon']);
+    $tue_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['tue']);
+    $wed_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['wed']);
+    $thur_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['thur']);
+    $fri_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['fri']);
+    $sat_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['sat']);
+    $sun_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['sun']);
+
+    $edit_session = "UPDATE Session_Names " .
+      " SET Session_Name='$name_sqlsafe'," .
+      "     Start_Hour='$start_hour_sqlsafe'," .
+      "     Start_Suffix='$start_suffix_sqlsafe'," .
+      "     End_Hour='$end_hour_sqlsafe'," .
+      "     End_Suffix='$end_suffix_sqlsafe'," .
+      "     Monday='$mon_sqlsafe'," .
+      "     Tuesday='$tue_sqlsafe'," .
+      "     Wednesday='$wed_sqlsafe'," .
+      "     Thursday='$thur_sqlsafe'," .
+      "     Friday='$fri_sqlsafe'," .
+      "     Saturday='$sat_sqlsafe'," .
+      "     Sunday='$sun_sqlsafe'" .
+      " WHERE Session_ID='" . $_POST['id'] . "'";
     mysqli_query($cnnEnlace, $edit_session);
     include "../include/dbconnclose.php";
 }

--- a/enlace/ajax/session_info.php
+++ b/enlace/ajax/session_info.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ *   TTM is a web application to manage data collected by community organizations.
+ *   Copyright (C) 2014, 2015  Local Initiatives Support Corporation (lisc.org)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+?>
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php";
+include $_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php";
+
+user_enforce_has_access($Enlace_id, $DataEntryAccess);
+
+header("Content-type:application/json");
+
+include "../include/dbconnopen.php";
+$session_id_sqlsafe = mysqli_real_escape_string($cnnEnlace, $_POST['id']);
+
+if($session_id_sqlsafe != '') {
+    $session_info_sql = "SELECT * FROM Session_Names WHERE Session_ID = '$session_id_sqlsafe'";
+    $session_info = mysqli_fetch_array(mysqli_query($cnnEnlace, $session_info_sql));
+    
+    echo json_encode(array(
+      'name' => $session_info['Session_Name'],
+      'start_hour' => $session_info['Start_Hour'],
+      'start_suffix' => $session_info['Start_Suffix'],
+      'end_hour' => $session_info['End_Hour'],
+      'end_suffix' => $session_info['End_Suffix'],
+      'monday' => $session_info['Monday'],
+      'tuesday' => $session_info['Tuesday'],
+      'wednesday' => $session_info['Wednesday'],
+      'thursday' => $session_info['Thursday'],
+      'friday' => $session_info['Friday'],
+      'saturday' => $session_info['Saturday'],
+      'sunday' => $session_info['Sunday']
+    ));
+}
+?>

--- a/enlace/include/dosage_percentage.php
+++ b/enlace/include/dosage_percentage.php
@@ -190,7 +190,7 @@ if(!function_exists("calculate_dosage")) {
         }
         /* Find the hours this person spent in the program. */
         /* Get daily hours: */
-        $program_daily_hours="SELECT Start_Hour, Start_Suffix, End_Hour, End_Suffix,"
+        $program_daily_hours="SELECT Session_Names.Start_Hour, Session_Names.Start_Suffix, Session_Names.End_Hour, Session_Names.End_Suffix,"
             . " Max_Hours FROM Programs INNER JOIN Session_Names "
             . " ON Session_Names.Program_ID=Programs.Program_ID WHERE Session_ID='$session_sqlsafe'";
         $program_hours_per_day = mysqli_query($cnnEnlace, $program_daily_hours);

--- a/enlace/programs/profile.php
+++ b/enlace/programs/profile.php
@@ -1168,7 +1168,33 @@ while ($sess = mysqli_fetch_array($sessions)) {
                                                          alert('Can\'t Generate: Please choose days of week of the program.');
                                                      }
                                            ">Generate Attendance Sheets</a>)
-                                     <?php } ?></td></tr>
+                                     <?php } ?>
+                                    <?php
+                                    $days = Array();
+                                    if($sess["Monday"]) { $days[] = "Mon"; }
+                                    if($sess["Tuesday"]) { $days[] = "Tue"; }
+                                    if($sess["Wednesday"]) { $days[] = "Wed"; }
+                                    if($sess["Thursday"]) { $days[] = "Thur"; }
+                                    if($sess["Friday"]) { $days[] = "Fri"; }
+                                    if($sess["Saturday"]) { $days[] = "Sat"; }
+                                    if($sess["Sunday"]) { $days[] = "Sun"; }
+
+                                    if(sizeof($days) > 0) {
+                                    echo "<br/>(";
+                                    echo join("/", $days);
+
+                                    if($sess["Start_Hour"]) {
+                                        echo ", ";
+                                        echo $sess["Start_Hour"];
+                                        echo $sess["Start_Suffix"];
+                                        echo " - ";
+                                        echo $sess["End_Hour"];
+                                        echo $sess["End_Suffix"];
+                                    }
+                                    echo ")";
+                                    }
+                                    ?>
+    </td></tr>
                             <tr class="toggler_<?php echo $sess[0] ?> hide_dates"><td class="all_projects" ><strong>Dates:</strong> <?php echo $sess[3] . ' --- ' . $sess[4]; ?></td>
                                 <td class="all_projects"><strong>Surveys Due:</strong> <?php echo $sess[5]; ?></td></tr><?php
                         }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1055,6 +1055,10 @@ div#enlace_participants table.search_table td {
 	padding: 3px 8px;
 }
 
+table.enlace_session_edit td {
+  border:1px solid black;
+}
+
 tr.unmarked {
   background-color:#FF9;
 }


### PR DESCRIPTION
This adds the days of week, and start/end times, to sessions as a separate entity from programs.  This affects reports as well, because dosages change related to how many hours a participant was in a session.

Test by adding or modifying sessions and updating the days of week and start/end times.

Merged against 221 to save rebasing time for testing