### PR TITLE
Fix #223: Fix add new institution

### DIFF
--- a/enlace/ajax/new_inst.php
+++ b/enlace/ajax/new_inst.php
@@ -49,7 +49,7 @@ $new_inst="INSERT INTO Institutions (Institution_Name, Institution_Type, Address
     '".$dir_sqlsafe."',
     '".$street_sqlsafe."',
     '".$suff_sqlsafe."',
-        $block_group,
+        '$block_group',
     '".$person_sqlsafe."',
     '".$phone_sqlsafe."',
     '".$email_sqlsafe."'


### PR DESCRIPTION
The root cause is that the google block lookup no longer works, but the database call needed to be updated regardless.

Test by adding a new institution.

Merged against 222 for easy rebasing.