### PR TITLE
Fix #240: Enlace: Remove survey Duplication

### DIFF
--- a/enlace/ajax/add_participant.php
+++ b/enlace/ajax/add_participant.php
@@ -120,27 +120,6 @@ if ($_POST['action'] == 'link_event') {
             mysqli_query($cnnEnlace, $add_person_to_program);
             include "../include/dbconnclose.php";
             
-            // Construct a participant object
-            $participant = new Participant();
-            $participant->load_with_participant_id($id);
-            
-            // Find the participants surveys are impact surveys from the last 6 months. 
-            $assessments = $participant->find_previous_surveys(6, Assessment::IMPACT_TYPE);
-            if ($assessments) {
-	            	// A survey exists, we should now duplicate the newest (first in array)
-	            	$assessment = $assessments[0];
-	            	
-	            	// Removing the primary key will cause Assessment to create a new one on Assessment->save()
-	            	$assessment->assessment_id = null;
-	            	
-	            	// Change the type and session
-	            	$assessment->pre_post = Assessment::INTAKE_TYPE;
-	            	$assessment->session_id = $program_id_sqlsafe;
-	            	
-	            	// Save this back to the database
-	            	$assessment->save();
-            }
-            
     }
     
     ?>

--- a/enlace/ajax/join_program.php
+++ b/enlace/ajax/join_program.php
@@ -206,28 +206,5 @@ else {
     $add_person_to_program = "INSERT INTO Participants_Programs (Participant_ID, Program_ID) VALUES ('$participant_sqlsafe', '$program_id_sqlsafe')";
     mysqli_query($cnnEnlace, $add_person_to_program);
     include "../include/dbconnclose.php";
-    
-    // Construct a participant object
-    $participant = new Participant();
-    $participant->load_with_participant_id($participant_sqlsafe);
-
-    // Find the participants surveys are impact surveys from the last 6 months. 
-    $assessments = $participant->find_previous_surveys(6, Assessment::IMPACT_TYPE);
-    print_r($assessments);
-    if ($assessments) {
-        // A survey exists, we should now duplicate the newest (first in array)
-        $assessment = $assessments[0];
-        
-        // Removing the primary key will cause Assessment to create a new one on Assessment->save()
-        $assessment->assessment_id = null;
-        
-        // Change the type and session
-        $assessment->pre_post = Assessment::INTAKE_TYPE;
-        $assessment->session_id = $program_id_sqlsafe;
-        
-        // Save this back to the database
-        $assessment->save();
-
-    }
 }
 ?>


### PR DESCRIPTION
Removes the code that duplicated surveys, because that code turned out to not only be in error, but also unneeded.

Test by adding a participant to a program when they have a recent survey, and then see that no new survey is created.