### PR TITLE
Fix #227: Lock attendance for the month.

### DIFF
--- a/enlace/ajax/add_absence.php
+++ b/enlace/ajax/add_absence.php
@@ -22,11 +22,20 @@ include $_SERVER['DOCUMENT_ROOT'] . "/include/dbconnopen.php";
 include $_SERVER['DOCUMENT_ROOT'] . "/core/include/setup_user.php";
 user_enforce_has_access($Enlace_id, $DataEntryAccess);
 
+include "../include/attendance.php";
+
 /*basic adding and removing of absences*/
     include "../include/dbconnopen.php";
     $user_id_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['user_id']);
     $date_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['date']);
     $row_id_select="SELECT Absence_ID FROM Absences WHERE Participant_ID = '$user_id_sqlsafe' AND Program_Date = '$date_sqlsafe'";
+
+$program_date_query = "SELECT Date_Listed FROM Program_Dates WHERE Program_Date_ID = '$date_sqlsafe'";
+$date = mysqli_fetch_row(mysqli_query($cnnEnlace, $program_date_query))[0];
+
+if(invalid_attendance_date(strtotime($date))) {
+    throw new Exception("Can't edit this date, which should have been disabled on page");
+}
 
 if ($_POST['action']=='absent'){
     include "../include/dbconnopen.php";

--- a/enlace/include/attendance.php
+++ b/enlace/include/attendance.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ *   TTM is a web application to manage data collected by community organizations.
+ *   Copyright (C) 2014, 2015  Local Initiatives Support Corporation (lisc.org)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+?>
+<?php
+
+if (!function_exists("invalid_attendance_date")) {
+    date_default_timezone_set('America/Chicago');
+    $now = new DateTime();
+    if($now->format("j") > 15) {
+        $earliest_acceptable_attendance_date = strtotime("midnight first day of this month");
+    } else {
+        $earliest_acceptable_attendance_date = strtotime("midnight first day of last month");
+    }
+    
+    function invalid_attendance_date ( $date ) {
+        global $earliest_acceptable_attendance_date;
+        return $date < $earliest_acceptable_attendance_date;
+    }
+}
+?>    

--- a/enlace/programs/profile.php
+++ b/enlace/programs/profile.php
@@ -27,6 +27,7 @@ include "../../header.php";
 include "../header.php";
 include "../classes/program.php";
 include "../include/settings.php";
+include "../include/attendance.php";
 require_once("../classes/assessment.php");
 $program = new Program();
 $program->load_with_program_id($_COOKIE['program']);
@@ -1252,9 +1253,11 @@ while ($sess = mysqli_fetch_array($sessions)) {
                                             <?php if(!($was_there || $was_absent)) { echo "class='unmarked'"; } ?>>
                                             <td><span style="font-weight:bold"><?php echo $all_p['First_Name'] . " " . $all_p['Last_Name']; ?></span></td>
                                             <td><input type="checkbox" <?php echo($was_there ? 'checked="true"' : null); ?>
+                                                <?php if(invalid_attendance_date($show_date)) { ?>disabled="disabled" <?php } ?>
                                                        id="present_date_<?php echo $temp_program['Program_Date_ID']; ?>_person_<?php echo $all_p['Participant_ID'] ?>"
                                                        onchange="markPresent(this, '<?php echo $temp_program['Program_Date_ID']; ?>', '<?php echo $all_p['Participant_ID'] ?>');"></td>
                                             <td><input type="checkbox" <?php echo($was_absent ? 'checked="true"' : null); ?>
+                                                <?php if(invalid_attendance_date($show_date)) { ?>disabled="disabled" <?php } ?>
                                                        id="absent_date_<?php echo $temp_program['Program_Date_ID']; ?>_person_<?php echo $all_p['Participant_ID'] ?>"
                                                        onchange="markAbsent(this, '<?php echo $temp_program['Program_Date_ID']; ?>', '<?php echo $all_p['Participant_ID'] ?>');"></td>
                                     </tr>


### PR DESCRIPTION
This is after the 15th of the month has passed, the previous month is disabled for attendance entering.

Test by looking at attendance for programs with previous months and seeing them be greyed out.