### PR TITLE
Fix #231: Update Session Name Dialog

### DIFF
--- a/enlace/ajax/add_program.php
+++ b/enlace/ajax/add_program.php
@@ -33,13 +33,19 @@ $id = mysqli_insert_id($cnnEnlace);
 date_default_timezone_set('America/Chicago');
 $end_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['end']);
 $session_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['session']);
+$session_year_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['session_year']);
+$session_type_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['session_type']);
+$session_name =
+    ($session_year_sqlsafe != '' ? "FY$session_year_sqlsafe-" : "") .
+    ($session_type_sqlsafe != '' ? "$session_type_sqlsafe-" : "") .
+    $session_sqlsafe;
 $start_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['start']);
 $end_session = new DateTime($_POST['end']);
 $survey_date = $end_session->sub(new DateInterval('P7D'));
 $survey_date = $survey_date->format('Y-m-d');
 
 /* make a new session, because every program has to have a session. */
-$create_session = "INSERT INTO Session_Names (Session_Name, Program_ID, Start_Date, End_Date, Survey_Due) VALUES ('" . $session_sqlsafe . "',
+$create_session = "INSERT INTO Session_Names (Session_Name, Program_ID, Start_Date, End_Date, Survey_Due) VALUES ('" . $session_name . "',
             $id, '" . $start_sqlsafe . "', '" . $end_sqlsafe . "', '" . $survey_date . "' )";
 mysqli_query($cnnEnlace, $create_session);
 

--- a/enlace/ajax/edit_program.php
+++ b/enlace/ajax/edit_program.php
@@ -37,6 +37,12 @@ if ($_POST['action'] == 'new_session') {
     $survey_date = $survey_date->format('Y-m-d');
 
     $name_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['name']);
+    $session_year_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['session_year']);
+    $session_type_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['session_type']);
+    $session_name =
+        ($session_year_sqlsafe != '' ? "FY$session_year_sqlsafe-" : "") .
+        ($session_type_sqlsafe != '' ? "$session_type_sqlsafe-" : "") .
+        $name_sqlsafe;
 
     $start_hour_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['start_hour']);
     $end_hour_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['end_hour']);
@@ -56,7 +62,7 @@ if ($_POST['action'] == 'new_session') {
         "  Start_Hour, Start_Suffix, End_Hour, End_Suffix, Monday," .
         "  Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)" .
         " VALUES" .
-        " ('$name_sqlsafe', '$program_sqlsafe', '$start_sqlsafe', '$end_sqlsafe', '$survey_date', " .
+        " ('$session_name', '$program_sqlsafe', '$start_sqlsafe', '$end_sqlsafe', '$survey_date', " .
         "  '$start_hour_sqlsafe', '$start_suffix_sqlsafe', '$end_hour_sqlsafe', '$end_suffix_sqlsafe', " .
         "  '$mon_sqlsafe', '$tue_sqlsafe', '$wed_sqlsafe', '$thur_sqlsafe', '$fri_sqlsafe', " .
         "  '$sat_sqlsafe', '$sun_sqlsafe')";

--- a/enlace/programs/profile.php
+++ b/enlace/programs/profile.php
@@ -162,6 +162,8 @@ Shows all program information.
             {
                 action: 'new_session',
                 name: document.getElementById('new_session_name').value,
+                session_year: document.getElementById('new_session_name_year').value,
+                session_type: document.getElementById('new_session_name_type').value,
                 program: '<?php echo $program->program_id; ?>',
                 start: document.getElementById('new_session_start').value,
                 end: document.getElementById('new_session_end').value,
@@ -520,8 +522,26 @@ Shows all program information.
                     <span class="helptext">Adding a new session of the program allows you to add a new set of participants and dates.  It's appropriate for 
                         adding spring and fall versions of a program, or a new year altogether.  Be sure to title the session clearly - "Spring 2013" is better than "Spring."</span>
                     <br/><br/>
-                    <table class="enlace_session_edit" style="width:350px;">
-                        <tr><td><strong>Name: </strong></td><td><input type="text" id="new_session_name" style="width:150px;"></td></tr>
+                    <table class="enlace_session_edit" style="width:550px;">
+                        <tr><td><strong>Name: </strong></td>
+                            <td>
+                                <select id="new_session_name_year">
+                                    <?php
+                                        $last_year = (int)date('Y') - 1;
+                                        for($i = 0 ; $i < 5 ; $i++) {
+                                            $year = $i + $last_year;
+                                            echo "<option value=\"$year\">$year</option>";
+                                        }
+                                    ?>
+                                    <option value="">N/A</option>
+                                </select>
+                                <select id="new_session_name_type">
+                                    <option value="School">School</option>
+                                    <option value="Summer">Summer</option>
+                                    <option value="">N/A</option>
+                                </select>
+                                <input type="text" id="new_session_name" style="width:150px;">
+                            </td></tr>
                         <tr><td><strong>Start Date: </strong></td><td><input type="text" id="new_session_start" class="addDP"></td></tr>
                         <tr><td><strong>End Date: </strong></td><td><input type="text" id="new_session_end" class="addDP"></td></tr>
 

--- a/enlace/programs/programs.php
+++ b/enlace/programs/programs.php
@@ -252,7 +252,23 @@ List of all programs, and, at the bottom, a place to add a new program.
             -->
             <tr><td><strong>Name a session:</strong><br>
                     <span class="helptext">You must include a first session name<br> or the program will not display correctly</span></td>
-                <td><input type="text" id="new_session_name"></td></tr>
+                <td>
+                    <select id="new_session_name_year">
+                        <?php
+                            $last_year = (int)date('Y') - 1;
+                            for($i = 0 ; $i < 5 ; $i++) {
+                                $year = $i + $last_year;
+                                echo "<option value=\"$year\">$year</option>";
+                            }
+                        ?>
+                        <option value="">N/A</option>
+                    </select>
+                    <select id="new_session_name_type">
+                        <option value="School">School</option>
+                        <option value="Summer">Summer</option>
+                        <option value="">N/A</option>
+                    </select>
+                    <input type="text" id="new_session_name"></td></tr>
             <tr><td><strong>Session Start:</strong></td><td><input type="text" id="new_session_start" class="addDP"></td></tr>
             <tr><td><strong>Session End:</strong></td><td><input type="text" id="new_session_end" class="addDP"></td></tr>
             <tr><td><strong>Session Surveys Due:</strong></td><td><span class="helptext">Surveys will be due one week before the entered end date for this session.</span>
@@ -271,6 +287,8 @@ List of all programs, and, at the bottom, a place to add a new program.
                                                            name: document.getElementById('new_name').value,
                                                            host: document.getElementById('new_host').value,
                                                            session: document.getElementById('new_session_name').value,
+                                                           session_year: document.getElementById('new_session_name_year').value,
+                                                           session_type: document.getElementById('new_session_name_type').value,
                                                            start: document.getElementById('new_session_start').value,
                                                            end: document.getElementById('new_session_end').value
                                                                    // survey: document.getElementById('new_session_surveys_due').value


### PR DESCRIPTION
Test by adding a new session and seeing the dropdown as required.  Then test that you can opt out of some of the dropdowns and the session name is sane.