### PR TITLE
Fix saving anonymous survey saving.

### DIFF
--- a/enlace/ajax/save_assessments.php
+++ b/enlace/ajax/save_assessments.php
@@ -105,7 +105,7 @@ $future_id_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['future_id']);
 $assessment_id_sqlsafe = mysqli_real_escape_string($cnnEnlace, $_POST['assessment_id']);
 $draft_sqlsafe=mysqli_real_escape_string($cnnEnlace, $_POST['draft']);
 
-if (!$USER->has_site_access($Enlace_id, $AdminAccess)) {
+if ($anonymous_entry || !$USER->has_site_access($Enlace_id, $AdminAccess)) {
     date_default_timezone_set('America/Chicago');
     $entered_date = strtotime($base_date_sqlsafe);
     if($_POST['base_date'] == '' || $entered_date > strtotime('now') || $entered_date < strtotime('-6 weeks')) {


### PR DESCRIPTION
When saving an anonymous survey, there was a new additional check
against the logged in user in order to see what dates were valid to
check, preventing saving the survey.

Issue #221: Add survey entry point link that doesn't require login
Issue #225: Force survey administer date to be within a given time
            window of current date